### PR TITLE
fix article sync for not changed articles

### DIFF
--- a/Components/Blisstribute/Article/Sync.php
+++ b/Components/Blisstribute/Article/Sync.php
@@ -97,8 +97,7 @@ class Shopware_Components_Blisstribute_Article_Sync extends Shopware_Components_
 
                             $currentArticle->setTriggerSync(false)
                                 ->setLastCronAt(new DateTime())
-                                ->setComment($ex->getMessage())
-                                ->setTries($currentArticle->getTries() + 1);
+                                ->setComment($ex->getMessage());
 
                             $this->modelManager->persist($currentArticle);
                             continue;


### PR DESCRIPTION
If a sync for an article was triggered and no changes are detected, so the tries will be count up.

But after more than 5 tries, the article will not be sync anymore. So if a article has now changes, the sync will ignore this article.

This PR should fix that issue.